### PR TITLE
Update maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Twixes @neilkakkar @posthog-bot @yakkomajuri
+* @Twixes @dmarticus @k11kirky @posthog-bot

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Feedstock Maintainers
 =====================
 
 * [@Twixes](https://github.com/Twixes/)
-* [@neilkakkar](https://github.com/neilkakkar/)
+* [@dmarticus](https://github.com/dmarticus/)
 * [@posthog-bot](https://github.com/posthog-bot/)
-* [@yakkomajuri](https://github.com/yakkomajuri/)
-
+* [@k11kirky](https://github.com/k11kirky/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,6 @@ about:
 extra:
   recipe-maintainers:
     - Twixes
-    - yakkomajuri
-    - neilkakkar
+    - dmarticus
+    - k11kirky
     - posthog-bot


### PR DESCRIPTION
Removing ex-Hoglets @neilkakkar and @yakkomajuri as maintainers.
Adding @dmarticus and @k11kirky, who've been involved with `posthog-python`.